### PR TITLE
Install wrtc@0.4.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.16.4",
     "node-fetch": "^2.3.0",
     "uuid": "^3.3.2",
-    "wrtc": "^0.3.6"
+    "wrtc": "^0.4.1"
   },
   "devDependencies": {
     "eslint": "^5.15.1",


### PR DESCRIPTION
Since `wrtc` version is lower than `1.0.0`, the caret semver rule does not apply and we need to explicitly bump the minor version number here to install `wrtc` at its most recent version.

Great package, and useful examples, thanks!