### PR TITLE
recording-audio-video-stream windows patch 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+recording.mp4

--- a/examples/record-audio-video-stream/fluent-ffmpeg-multistream.js
+++ b/examples/record-audio-video-stream/fluent-ffmpeg-multistream.js
@@ -1,20 +1,20 @@
-const net = require("net");
-const fs = require("fs");
-const os = require("os");
+const net = require('net');
+const fs = require('fs');
+const os = require('os');
 
 var counter = 0;
 class UnixStream {
   constructor(stream, onSocket) {
     const path = `./${++counter}.sock`;
     this.url =
-      os.platform() === "win32" ? "\\\\.\\pipe\\" + path : "unix:" + path;
+      os.platform() === 'win32' ? '\\\\.\\pipe\\' + path : 'unix:' + path;
 
     try {
       fs.statSync(path);
       fs.unlinkSync(path);
     } catch (err) {}
     const server = net.createServer(onSocket);
-    stream.on("finish", () => {
+    stream.on('finish', () => {
       server.close();
     });
     server.listen(this.url);

--- a/examples/record-audio-video-stream/fluent-ffmpeg-multistream.js
+++ b/examples/record-audio-video-stream/fluent-ffmpeg-multistream.js
@@ -1,0 +1,32 @@
+const net = require("net");
+const fs = require("fs");
+const os = require("os");
+
+var counter = 0;
+class UnixStream {
+  constructor(stream, onSocket) {
+    const path = `./${++counter}.sock`;
+    this.url =
+      os.platform() === "win32" ? "\\\\.\\pipe\\" + path : "unix:" + path;
+
+    try {
+      fs.statSync(path);
+      fs.unlinkSync(path);
+    } catch (err) {}
+    const server = net.createServer(onSocket);
+    stream.on("finish", () => {
+      server.close();
+    });
+    server.listen(this.url);
+  }
+}
+
+function StreamInput(stream) {
+  return new UnixStream(stream, (socket) => stream.pipe(socket));
+}
+module.exports.StreamInput = StreamInput;
+
+function StreamOutput(stream) {
+  return new UnixStream(stream, (socket) => socket.pipe(stream));
+}
+module.exports.StreamOutput = StreamOutput;

--- a/examples/record-audio-video-stream/server.js
+++ b/examples/record-audio-video-stream/server.js
@@ -61,7 +61,7 @@ function beforeOffer(peerConnection) {
       });
 
       stream.proc = ffmpeg()
-        .addInput(StreamInput(stream.video).url)
+        .addInput(new StreamInput(stream.video).url)
         .addInputOptions([
           '-f',
           'rawvideo',
@@ -72,7 +72,7 @@ function beforeOffer(peerConnection) {
           '-r',
           '30',
         ])
-        .addInput(StreamInput(stream.audio).url)
+        .addInput(new StreamInput(stream.audio).url)
         .addInputOptions(['-f s16le', '-ar 48k', '-ac 1'])
         .on('start', () => {
           console.log('Start recording >> ', stream.recordPath);

--- a/examples/record-audio-video-stream/server.js
+++ b/examples/record-audio-video-stream/server.js
@@ -1,40 +1,36 @@
-/* eslint-disable linebreak-style */
-/* eslint-disable new-cap */
-/* eslint-disable no-unused-vars */
-/* eslint-disable linebreak-style */
-"use strict";
+'use strict';
 
-const { PassThrough } = require("stream");
-const fs = require("fs");
+const { PassThrough } = require('stream');
+const fs = require('fs');
 
-const { RTCAudioSink, RTCVideoSink } = require("wrtc").nonstandard;
+const { RTCAudioSink, RTCVideoSink } = require('wrtc').nonstandard;
 
-const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path;
-const ffmpeg = require("fluent-ffmpeg");
+const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
+const ffmpeg = require('fluent-ffmpeg');
 ffmpeg.setFfmpegPath(ffmpegPath);
-const { StreamInput } = require("./fluent-ffmpeg-multistream.js");
+const { StreamInput } = require('./fluent-ffmpeg-multistream.js');
 
-const VIDEO_OUTPUT_SIZE = "320x240";
-const VIDEO_OUTPUT_FILE = "./recording.mp4";
+const VIDEO_OUTPUT_SIZE = '320x240';
+const VIDEO_OUTPUT_FILE = './recording.mp4';
 
 let UID = 0;
 
 function beforeOffer(peerConnection) {
-  const audioTransceiver = peerConnection.addTransceiver("audio");
-  const videoTransceiver = peerConnection.addTransceiver("video");
+  const audioTransceiver = peerConnection.addTransceiver('audio');
+  const videoTransceiver = peerConnection.addTransceiver('video');
 
   const audioSink = new RTCAudioSink(audioTransceiver.receiver.track);
   const videoSink = new RTCVideoSink(videoTransceiver.receiver.track);
 
   const streams = [];
 
-  videoSink.addEventListener("frame", ({ frame: { width, height, data } }) => {
-    const size = width + "x" + height;
+  videoSink.addEventListener('frame', ({ frame: { width, height, data } }) => {
+    const size = width + 'x' + height;
     if (!streams[0] || (streams[0] && streams[0].size !== size)) {
       UID++;
 
       const stream = {
-        recordPath: "./recording-" + size + "-" + UID + ".mp4",
+        recordPath: './recording-' + size + '-' + UID + '.mp4',
         size,
         video: new PassThrough(),
         audio: new PassThrough(),
@@ -46,10 +42,10 @@ function beforeOffer(peerConnection) {
         }
       };
 
-      audioSink.addEventListener("data", onAudioData);
+      audioSink.addEventListener('data', onAudioData);
 
-      stream.audio.on("end", () => {
-        audioSink.removeEventListener("data", onAudioData);
+      stream.audio.on('end', () => {
+        audioSink.removeEventListener('data', onAudioData);
       });
 
       streams.unshift(stream);
@@ -67,23 +63,23 @@ function beforeOffer(peerConnection) {
       stream.proc = ffmpeg()
         .addInput(StreamInput(stream.video).url)
         .addInputOptions([
-          "-f",
-          "rawvideo",
-          "-pix_fmt",
-          "yuv420p",
-          "-s",
+          '-f',
+          'rawvideo',
+          '-pix_fmt',
+          'yuv420p',
+          '-s',
           stream.size,
-          "-r",
-          "30",
+          '-r',
+          '30',
         ])
         .addInput(StreamInput(stream.audio).url)
-        .addInputOptions(["-f s16le", "-ar 48k", "-ac 1"])
-        .on("start", () => {
-          console.log("Start recording >> ", stream.recordPath);
+        .addInputOptions(['-f s16le', '-ar 48k', '-ac 1'])
+        .on('start', () => {
+          console.log('Start recording >> ', stream.recordPath);
         })
-        .on("end", () => {
+        .on('end', () => {
           stream.recordEnd = true;
-          console.log("Stop recording >> ", stream.recordPath);
+          console.log('Stop recording >> ', stream.recordPath);
         })
         .size(VIDEO_OUTPUT_SIZE)
         .output(stream.recordPath);
@@ -117,14 +113,14 @@ function beforeOffer(peerConnection) {
             clearTimeout(timer);
 
             const mergeProc = ffmpeg()
-              .on("start", () => {
-                console.log("Start merging into " + VIDEO_OUTPUT_FILE);
+              .on('start', () => {
+                console.log('Start merging into ' + VIDEO_OUTPUT_FILE);
               })
-              .on("end", () => {
+              .on('end', () => {
                 streams.forEach(({ recordPath }) => {
                   fs.unlinkSync(recordPath);
                 });
-                console.log("Merge end. You can play " + VIDEO_OUTPUT_FILE);
+                console.log('Merge end. You can play ' + VIDEO_OUTPUT_FILE);
               });
 
             streams.forEach(({ recordPath }) => {

--- a/examples/record-audio-video-stream/server.js
+++ b/examples/record-audio-video-stream/server.js
@@ -1,39 +1,43 @@
-'use strict';
+/* eslint-disable linebreak-style */
+/* eslint-disable new-cap */
+/* eslint-disable no-unused-vars */
+/* eslint-disable linebreak-style */
+"use strict";
 
-const { PassThrough } = require('stream')
-const fs = require('fs')
+const { PassThrough } = require("stream");
+const fs = require("fs");
 
-const { RTCAudioSink, RTCVideoSink } = require('wrtc').nonstandard;
+const { RTCAudioSink, RTCVideoSink } = require("wrtc").nonstandard;
 
-const ffmpegPath = require('@ffmpeg-installer/ffmpeg').path;
-const ffmpeg = require('fluent-ffmpeg');
+const ffmpegPath = require("@ffmpeg-installer/ffmpeg").path;
+const ffmpeg = require("fluent-ffmpeg");
 ffmpeg.setFfmpegPath(ffmpegPath);
-const { StreamInput } = require('fluent-ffmpeg-multistream')
+const { StreamInput } = require("./fluent-ffmpeg-multistream.js");
 
-const VIDEO_OUTPUT_SIZE = '320x240'
-const VIDEO_OUTPUT_FILE = './recording.mp4'
+const VIDEO_OUTPUT_SIZE = "320x240";
+const VIDEO_OUTPUT_FILE = "./recording.mp4";
 
 let UID = 0;
 
 function beforeOffer(peerConnection) {
-  const audioTransceiver = peerConnection.addTransceiver('audio');
-  const videoTransceiver = peerConnection.addTransceiver('video');
-  
+  const audioTransceiver = peerConnection.addTransceiver("audio");
+  const videoTransceiver = peerConnection.addTransceiver("video");
+
   const audioSink = new RTCAudioSink(audioTransceiver.receiver.track);
   const videoSink = new RTCVideoSink(videoTransceiver.receiver.track);
 
   const streams = [];
 
-  videoSink.addEventListener('frame', ({ frame: { width, height, data }}) => {
-    const size = width + 'x' + height;
+  videoSink.addEventListener("frame", ({ frame: { width, height, data } }) => {
+    const size = width + "x" + height;
     if (!streams[0] || (streams[0] && streams[0].size !== size)) {
       UID++;
 
       const stream = {
-        recordPath: './recording-' + size + '-' + UID + '.mp4',
+        recordPath: "./recording-" + size + "-" + UID + ".mp4",
         size,
         video: new PassThrough(),
-        audio: new PassThrough()
+        audio: new PassThrough(),
       };
 
       const onAudioData = ({ samples: { buffer } }) => {
@@ -42,15 +46,15 @@ function beforeOffer(peerConnection) {
         }
       };
 
-      audioSink.addEventListener('data', onAudioData);
+      audioSink.addEventListener("data", onAudioData);
 
-      stream.audio.on('end', () => {
-        audioSink.removeEventListener('data', onAudioData);
+      stream.audio.on("end", () => {
+        audioSink.removeEventListener("data", onAudioData);
       });
 
       streams.unshift(stream);
 
-      streams.forEach(item=>{
+      streams.forEach((item) => {
         if (item !== stream && !item.end) {
           item.end = true;
           if (item.audio) {
@@ -58,44 +62,44 @@ function beforeOffer(peerConnection) {
           }
           item.video.end();
         }
-      })
-  
+      });
+
       stream.proc = ffmpeg()
-        .addInput((new StreamInput(stream.video)).url)
+        .addInput(StreamInput(stream.video).url)
         .addInputOptions([
-          '-f', 'rawvideo',
-          '-pix_fmt', 'yuv420p',
-          '-s', stream.size,
-          '-r', '30',
+          "-f",
+          "rawvideo",
+          "-pix_fmt",
+          "yuv420p",
+          "-s",
+          stream.size,
+          "-r",
+          "30",
         ])
-        .addInput((new StreamInput(stream.audio)).url)
-        .addInputOptions([
-          '-f s16le',
-          '-ar 48k',
-          '-ac 1',
-        ])
-        .on('start', ()=>{
-          console.log('Start recording >> ', stream.recordPath)
+        .addInput(StreamInput(stream.audio).url)
+        .addInputOptions(["-f s16le", "-ar 48k", "-ac 1"])
+        .on("start", () => {
+          console.log("Start recording >> ", stream.recordPath);
         })
-        .on('end', ()=>{
+        .on("end", () => {
           stream.recordEnd = true;
-          console.log('Stop recording >> ', stream.recordPath)
+          console.log("Stop recording >> ", stream.recordPath);
         })
         .size(VIDEO_OUTPUT_SIZE)
         .output(stream.recordPath);
 
-        stream.proc.run();
+      stream.proc.run();
     }
 
     streams[0].video.push(Buffer.from(data));
   });
 
   const { close } = peerConnection;
-  peerConnection.close = function() {
+  peerConnection.close = function () {
     audioSink.stop();
     videoSink.stop();
 
-    streams.forEach(({ audio, video, end, proc, recordPath })=>{
+    streams.forEach(({ audio, video, end, proc, recordPath }) => {
       if (!end) {
         if (audio) {
           audio.end();
@@ -105,38 +109,36 @@ function beforeOffer(peerConnection) {
     });
 
     let totalEnd = 0;
-    const timer = setInterval(()=>{
-      streams.forEach(stream=>{
+    const timer = setInterval(() => {
+      streams.forEach((stream) => {
         if (stream.recordEnd) {
           totalEnd++;
           if (totalEnd === streams.length) {
             clearTimeout(timer);
 
             const mergeProc = ffmpeg()
-              .on('start', ()=>{
-                console.log('Start merging into ' + VIDEO_OUTPUT_FILE);
+              .on("start", () => {
+                console.log("Start merging into " + VIDEO_OUTPUT_FILE);
               })
-              .on('end', ()=>{
-                streams.forEach(({ recordPath })=>{
+              .on("end", () => {
+                streams.forEach(({ recordPath }) => {
                   fs.unlinkSync(recordPath);
-                })
-                console.log('Merge end. You can play ' + VIDEO_OUTPUT_FILE);
+                });
+                console.log("Merge end. You can play " + VIDEO_OUTPUT_FILE);
               });
-        
-            streams.forEach(({ recordPath })=>{
-              mergeProc.addInput(recordPath)
+
+            streams.forEach(({ recordPath }) => {
+              mergeProc.addInput(recordPath);
             });
-        
-            mergeProc
-              .output(VIDEO_OUTPUT_FILE)
-              .run();
+
+            mergeProc.output(VIDEO_OUTPUT_FILE).run();
           }
         }
       });
-    }, 1000)
+    }, 1000);
 
     return close.apply(this, arguments);
-  }
+  };
 }
 
 module.exports = { beforeOffer };


### PR DESCRIPTION
**Windows Compatibility Patch** (custom _fluent-ffmpeg-multistream_ implementation) because unix ports aren't readily accessible and creating a PR to the original dependency's repository is literally not an option.

Outside of whitespace and formatting, the only real edit to the server.js is
```
const { StreamInput } = require('./fluent-ffmpeg-multistream.js');
```